### PR TITLE
Fix #6 by creating class TextTexture

### DIFF
--- a/CONTROL
+++ b/CONTROL
@@ -1,4 +1,4 @@
 Source: sss-gl
-Version: 0.6.0
+Version: 0.6.1
 Description: OpenGL abstraction in C++, using GLFW, Glad, and GLM
 Build-Depends: glfw3, glad, glm, stb, sss-commons, sss-text-rendering

--- a/GL.vcxproj
+++ b/GL.vcxproj
@@ -28,10 +28,10 @@
   <ItemGroup>
     <ClInclude Include="inc\SSS\GL.hpp" />
     <ClInclude Include="inc\SSS\GL\Button.hpp" />
-    <ClInclude Include="inc\SSS\GL\Init.hpp" />
     <ClInclude Include="inc\SSS\GL\Model.hpp" />
     <ClInclude Include="inc\SSS\GL\Shaders.hpp" />
     <ClInclude Include="inc\SSS\GL\Plane.hpp" />
+    <ClInclude Include="inc\SSS\GL\TextTexture.hpp" />
     <ClInclude Include="inc\SSS\GL\Texture2D.hpp" />
     <ClInclude Include="inc\SSS\GL\Window.hpp" />
     <ClInclude Include="inc\SSS\GL\_internal\callbacks.hpp" />
@@ -41,12 +41,12 @@
   <ItemGroup>
     <ClCompile Include="src\Button.cpp" />
     <ClCompile Include="src\Model.cpp" />
+    <ClCompile Include="src\TextTexture.cpp" />
     <ClCompile Include="src\_internal\callbacks.cpp" />
     <ClCompile Include="src\_internal\pointers.cpp" />
     <ClCompile Include="src\Shaders.cpp" />
     <ClCompile Include="src\Plane.cpp" />
     <ClCompile Include="src\Window.cpp" />
-    <ClCompile Include="src\Init.cpp" />
     <ClCompile Include="src\Texture2D.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/GL.vcxproj.filters
+++ b/GL.vcxproj.filters
@@ -57,7 +57,7 @@
     <ClCompile Include="src\_internal\pointers.cpp">
       <Filter>src\_internal</Filter>
     </ClCompile>
-    <ClCompile Include="src\Init.cpp">
+    <ClCompile Include="src\TextTexture.cpp">
       <Filter>src</Filter>
     </ClCompile>
   </ItemGroup>
@@ -92,7 +92,7 @@
     <ClInclude Include="inc\SSS\GL\_internal\includes.hpp">
       <Filter>inc\_internal</Filter>
     </ClInclude>
-    <ClInclude Include="inc\SSS\GL\Init.hpp">
+    <ClInclude Include="inc\SSS\GL\TextTexture.hpp">
       <Filter>inc</Filter>
     </ClInclude>
   </ItemGroup>

--- a/inc/SSS/GL.hpp
+++ b/inc/SSS/GL.hpp
@@ -6,4 +6,4 @@
 #include <SSS/GL/Plane.hpp>
 #include <SSS/GL/Button.hpp>
 #include <SSS/GL/Texture2D.hpp>
-#include <SSS/GL/TextAreaTexture.hpp>
+#include <SSS/GL/TextTexture.hpp>

--- a/inc/SSS/GL/Button.hpp
+++ b/inc/SSS/GL/Button.hpp
@@ -11,7 +11,7 @@ class Button : public Plane {
 
 protected:
     Button() = default;
-    Button(Texture2D::Shared texture, GLFWwindow const* context);
+    Button(TextureBase::Shared texture, GLFWwindow const* context);
 
 public:
     virtual ~Button() = default;

--- a/inc/SSS/GL/Plane.hpp
+++ b/inc/SSS/GL/Plane.hpp
@@ -17,19 +17,19 @@ private:
 
 protected:
     Plane();
-    Plane(Texture2D::Shared texture);
+    Plane(TextureBase::Shared texture);
 public:
     virtual ~Plane() = default;
 
     using Shared = std::shared_ptr<Plane>;
     
-    void useTexture(Texture2D::Shared texture);
+    void useTexture(TextureBase::Shared texture);
 
     virtual glm::mat4 getModelMat4() noexcept;
     void draw() const;
 
 protected:
-    Texture2D::Shared _texture;
+    TextureBase::Shared _texture;
     GLsizei _tex_w{ 0 }, _tex_h{ 0 };
     glm::vec3 _tex_scaling{ 1 };
     

--- a/inc/SSS/GL/TextTexture.hpp
+++ b/inc/SSS/GL/TextTexture.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Texture2D.hpp"
+
+__SSS_GL_BEGIN
+
+class TextTexture : public TextureBase, public std::enable_shared_from_this<TextTexture> {
+private:
+    TextTexture(int width, int height);
+
+public:
+    ~TextTexture();
+    
+    using Shared = std::shared_ptr<TextTexture>;
+    static Shared create(int width, int height);
+
+    virtual void bind();
+
+    void clear() noexcept;
+    void useBuffer(TR::Buffer::Shared buffer);
+    void scroll(int pixels) noexcept;
+    void setTypeWriter(bool activate) noexcept;
+    bool incrementCursor() noexcept;
+
+private:
+    bool _update_texture{ true };
+    TR::TextArea::Shared _text_area;
+};
+
+__SSS_GL_END

--- a/inc/SSS/GL/Texture2D.hpp
+++ b/inc/SSS/GL/Texture2D.hpp
@@ -4,7 +4,23 @@
 
 __SSS_GL_BEGIN
 
-class Texture2D : public std::enable_shared_from_this<Texture2D> {
+class TextureBase {
+public:
+    using Shared = std::shared_ptr<TextureBase>;
+protected:
+    TextureBase(GLenum target) : _raw_texture(target) {};
+public:
+    TextureBase() = delete;
+    virtual void bind() { _raw_texture.bind(); };
+    inline void getDimensions(int& w, int& h) { w = _w; h = _h; };
+    inline RGBA32::Pixels const& getPixels() { return _pixels; };
+protected:
+    int _w{ 0 }, _h{ 0 };
+    _internal::Texture _raw_texture;
+    RGBA32::Pixels _pixels;
+};
+
+class Texture2D : public TextureBase, public std::enable_shared_from_this<Texture2D> {
     friend class Plane;
 
 protected:
@@ -34,27 +50,8 @@ public:
     void useFile(std::string filepath);
     void edit(void const* pixels, int width, int height);
 
-    virtual inline void bind() {
-        _raw_texture.bind();
-    };
-    // Returns stored pixels.
-    // The vector is only filled if the texture was generated via a file.
-    inline RGBA32::Pixels const& getPixels() const noexcept {
-        return _pixels;
-    };
-    inline void getDimensions(int& width, int& height) const noexcept {
-        width = _w;
-        height = _h;
-    };
-
 private:
-    int _w{ 0 }, _h{ 0 };
-    _internal::Texture _raw_texture{ GL_TEXTURE_2D };
-
 // --- Image loading ---
-
-    // Vector of pixels
-    RGBA32::Pixels _pixels;
 
     // Loading thread which fills _raw_pixels using stb_image
     class _LoadingThread : public ThreadBase <Texture2D::Weak, std::string> {

--- a/inc/SSS/GL/Window.hpp
+++ b/inc/SSS/GL/Window.hpp
@@ -75,9 +75,9 @@ public :
 
     Model::Shared createModel();
     Plane::Shared createPlane();
-    Plane::Shared createPlane(Texture2D::Shared texture);
+    Plane::Shared createPlane(TextureBase::Shared texture);
     Button::Shared createButton();
-    Button::Shared createButton(Texture2D::Shared texture);
+    Button::Shared createButton(TextureBase::Shared texture);
 
     void unloadModel(Model::Shared model);
     void unloadPlane(Plane::Shared plane);
@@ -191,7 +191,7 @@ private:
 
     void _setProjections();
 
-    static void _textureWasEdited(Texture2D::Shared texture);
+    static void _textureWasEdited(TextureBase::Shared texture);
 };
 
 __SSS_GL_END

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -3,7 +3,7 @@
 
 __SSS_GL_BEGIN
 
-Button::Button(Texture2D::Shared texture, GLFWwindow const* context) try
+Button::Button(TextureBase::Shared texture, GLFWwindow const* context) try
     : Plane::Plane(texture)
 {
     _updateWinScaling(context);

--- a/src/Plane.cpp
+++ b/src/Plane.cpp
@@ -53,14 +53,14 @@ Plane::Plane() try
 }
 __CATCH_AND_RETHROW_METHOD_EXC
 
-Plane::Plane(Texture2D::Shared texture) try
+Plane::Plane(TextureBase::Shared texture) try
     : Plane()
 {
     useTexture(texture);
 }
 __CATCH_AND_RETHROW_METHOD_EXC
 
-void Plane::useTexture(Texture2D::Shared texture)
+void Plane::useTexture(TextureBase::Shared texture)
 {
     _texture.swap(texture);
     _updateTexScaling();

--- a/src/TextTexture.cpp
+++ b/src/TextTexture.cpp
@@ -1,0 +1,61 @@
+#include "SSS/GL/TextTexture.hpp"
+
+__SSS_GL_BEGIN
+
+TextTexture::TextTexture(int width, int height)
+    : TextureBase(GL_TEXTURE_2D)
+{
+    _w = width;
+    _h = height;
+    _text_area = TR::TextArea::create(width, height);
+    _raw_texture.bind();
+    _raw_texture.parameteri(GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    _raw_texture.parameteri(GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    _raw_texture.parameteri(GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    _raw_texture.parameteri(GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+}
+
+TextTexture::~TextTexture()
+{
+}
+
+TextTexture::Shared TextTexture::create(int width, int height)
+{
+    return Shared(new TextTexture(width, height));
+}
+
+void TextTexture::bind()
+{
+    if (_text_area->willDraw() || _update_texture) {
+        _raw_texture.edit(_text_area->getPixels(), _w, _h);
+        _update_texture = false;
+    }
+    _raw_texture.bind();
+}
+
+void TextTexture::clear() noexcept
+{
+    _text_area->clear();
+}
+
+void TextTexture::useBuffer(TR::Buffer::Shared buffer)
+{
+    _text_area->useBuffer(buffer);
+}
+
+void TextTexture::scroll(int pixels) noexcept
+{
+    _update_texture = _text_area->scroll(pixels);
+}
+
+void TextTexture::setTypeWriter(bool activate) noexcept
+{
+    _text_area->setTypeWriter(activate);
+}
+
+bool TextTexture::incrementCursor() noexcept
+{
+    return _text_area->incrementCursor();
+}
+
+__SSS_GL_END

--- a/src/Texture2D.cpp
+++ b/src/Texture2D.cpp
@@ -15,6 +15,7 @@ bool Texture2D::LOG::destructor{ false };
 std::deque<Texture2D::Weak> Texture2D::_instances{};
 
 Texture2D::Texture2D() try
+    : TextureBase(GL_TEXTURE_2D)
 {
     _raw_texture.bind();
     _raw_texture.parameteri(GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -75,7 +76,7 @@ void Texture2D::edit(void const* pixels, int width, int height) try
     // Clear previous pixel storage
     _pixels.clear();
     // Update texture scaling of all planes (they are stored in window instances)
-    Window::_textureWasEdited(shared_from_this());
+    Window::_textureWasEdited(std::static_pointer_cast<TextureBase>(shared_from_this()));
 }
 __CATCH_AND_RETHROW_METHOD_EXC
 
@@ -113,7 +114,7 @@ void Texture2D::pollThreads()
                 // Give the image to the OpenGL texture
                 texture->_raw_texture.edit(&texture->_pixels[0], texture->_w, texture->_h);
                 // Update texture scaling of all planes (they are stored in window instances)
-                Window::_textureWasEdited(texture);
+                Window::_textureWasEdited(std::static_pointer_cast<TextureBase>(texture));
                 // Set thread as handled.
                 texture->_loading_thread.setAsHandled();
             }

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -147,7 +147,7 @@ Plane::Shared Window::createPlane()
         _planes.emplace_back(Plane::Shared(new Plane())));
 }
 
-Plane::Shared Window::createPlane(Texture2D::Shared texture)
+Plane::Shared Window::createPlane(TextureBase::Shared texture)
 {
     return Plane::Shared(
         _planes.emplace_back(Plane::Shared(new Plane(texture))));
@@ -159,7 +159,7 @@ Button::Shared Window::createButton()
         _buttons.emplace_back(Button::Shared(new Button())));
 }
 
-Button::Shared Window::createButton(Texture2D::Shared texture)
+Button::Shared Window::createButton(TextureBase::Shared texture)
 {
     return Button::Shared(
         _buttons.emplace_back(Button::Shared(new Button(texture, _window.get()))));
@@ -332,7 +332,7 @@ void Window::_setProjections()
     _ortho_mat4 = glm::ortho(-x, x, -y, y, _z_near, _z_far);
 }
 
-void Window::_textureWasEdited(Texture2D::Shared texture)
+void Window::_textureWasEdited(TextureBase::Shared texture)
 {
     for (auto it = _instances.cbegin(); it != _instances.cend(); ++it) {
         if (it->second.expired()) {


### PR DESCRIPTION
This fixes #6.
- New class TextureBase, which holds basic Texture functions.
- Texture2D now inherits from TextureBase.
- New class TextTexture which inherits from TextureBase, and stores a SSS::TR::TextArea, mixing both features.
- Plane and Button classes now require a TextureBase instead of Texture2D, so that TextTexture can be passed.