### PR TITLE
Fix #6 for good this time.

### DIFF
--- a/inc/SSS/GL/Button.hpp
+++ b/inc/SSS/GL/Button.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Plane.hpp"
+#include "TextTexture.hpp"
 
 __SSS_GL_BEGIN
 
@@ -41,6 +42,8 @@ private:
     ButtonFunction _f{ nullptr };
     // Mouse hovering state, always updated via the mouse position callback.
     bool _is_hovered{ false };
+    int _relative_x{ 0 };
+    int _relative_y{ 0 };
 
     // Updates window scaling when window is resized.
     void _updateWinScaling(GLFWwindow const* context);

--- a/inc/SSS/GL/TextTexture.hpp
+++ b/inc/SSS/GL/TextTexture.hpp
@@ -4,7 +4,10 @@
 
 __SSS_GL_BEGIN
 
-class TextTexture : public TextureBase, public std::enable_shared_from_this<TextTexture> {
+class TextTexture :
+    public TextureBase,
+    public TR::TextArea,
+    public std::enable_shared_from_this<TextTexture> {
 private:
     TextTexture(int width, int height);
 
@@ -16,15 +19,10 @@ public:
 
     virtual void bind();
 
-    void clear() noexcept;
-    void useBuffer(TR::Buffer::Shared buffer);
-    void scroll(int pixels) noexcept;
-    void setTypeWriter(bool activate) noexcept;
-    bool incrementCursor() noexcept;
+    bool scroll(int pixels) noexcept;
 
 private:
     bool _update_texture{ true };
-    TR::TextArea::Shared _text_area;
 };
 
 __SSS_GL_END

--- a/inc/SSS/GL/Texture2D.hpp
+++ b/inc/SSS/GL/Texture2D.hpp
@@ -12,10 +12,10 @@ protected:
 public:
     TextureBase() = delete;
     virtual void bind() { _raw_texture.bind(); };
-    inline void getDimensions(int& w, int& h) { w = _w; h = _h; };
-    inline RGBA32::Pixels const& getPixels() { return _pixels; };
+    inline void getDimensions(int& w, int& h) { w = _tex_w; h = _tex_h; };
+    inline RGBA32::Pixels const& getStoredPixels() { return _pixels; };
 protected:
-    int _w{ 0 }, _h{ 0 };
+    int _tex_w{ 0 }, _tex_h{ 0 };
     _internal::Texture _raw_texture;
     RGBA32::Pixels _pixels;
 };

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -22,6 +22,10 @@ __CATCH_AND_RETHROW_METHOD_EXC
 // Called whenever the button is clicked.
 void Button::callFunction() try
 {
+    TextTexture::Shared text_texture = std::dynamic_pointer_cast<TextTexture>(_texture);
+    if (text_texture) {
+        text_texture->placeCursor(_relative_x, _relative_y);
+    }
     if (_f == nullptr) {
         __LOG_METHOD_WRN("Function wasn't set.");
         return;
@@ -88,20 +92,22 @@ void Button::_updateHoverStatus(double x, double y) try
         return;
     }
 
+    // Update relative x & y positions.
+    float const x_range = v[0] - u[0],
+        y_range = v[1] - u[1],
+        x_diff = static_cast<float>(x) - u[0],
+        y_diff = static_cast<float>(y) - u[1];
+    _relative_x = static_cast<int>(x_diff / x_range * static_cast<float>(_tex_w));
+    _relative_y = _tex_h - static_cast<int>(y_diff / y_range * static_cast<float>(_tex_h));
+
     // If the button is a PNG, check the alpha channel of the pixel being hovered.
-    RGBA32::Pixels const& pixels = _texture->getPixels();
+    RGBA32::Pixels const& pixels = _texture->getStoredPixels();
     if (pixels.empty()) {
         _is_hovered = true;
     }
     else {
-        float const x_range = v[0] - u[0],
-            y_range = v[1] - u[1],
-            x_diff = static_cast<float>(x) - u[0],
-            y_diff = static_cast<float>(y) - u[1];
-        int const x_pos = static_cast<int>(x_diff / x_range * static_cast<float>(_tex_w)),
-            y_pos = _tex_h - static_cast<int>(y_diff / y_range * static_cast<float>(_tex_h));
         // Update status
-        size_t const pixel = static_cast<size_t>(y_pos * _tex_w + x_pos);
+        size_t const pixel = static_cast<size_t>(_relative_y * _tex_w + _relative_x);
         if (pixel < pixels.size()) {
             _is_hovered = pixels.at(pixel).bytes.a != 0;
         }

--- a/src/Texture2D.cpp
+++ b/src/Texture2D.cpp
@@ -69,10 +69,10 @@ __CATCH_AND_RETHROW_METHOD_EXC
 void Texture2D::edit(void const* pixels, int width, int height) try
 {
     // Update size info
-    _w = width;
-    _h = height;
+    _tex_w = width;
+    _tex_h = height;
     // Give the image to the OpenGL texture
-    _raw_texture.edit(pixels, _w, _h);
+    _raw_texture.edit(pixels, _tex_w, _tex_h);
     // Clear previous pixel storage
     _pixels.clear();
     // Update texture scaling of all planes (they are stored in window instances)
@@ -83,15 +83,15 @@ __CATCH_AND_RETHROW_METHOD_EXC
 void Texture2D::_LoadingThread::_function(Texture2D::Weak texture, std::string filepath)
 {
     auto& _pixels = texture.lock()->_pixels;
-    auto& _w = texture.lock()->_w;
-    auto& _h = texture.lock()->_h;
+    auto& _tex_w = texture.lock()->_tex_w;
+    auto& _tex_h = texture.lock()->_tex_h;
 
     // Load image
     SSS::C_Ptr <uint32_t, void(*)(void*), stbi_image_free>
         raw_pixels((uint32_t*)(stbi_load(
             filepath.c_str(),   // Filepath to picture
-            &_w,                // Width, to query
-            &_h,                // Height, to query
+            &_tex_w,                // Width, to query
+            &_tex_h,                // Height, to query
             nullptr,            // Byte composition, to query if not requested
             4                   // Byte composition, to request
         )));
@@ -101,7 +101,7 @@ void Texture2D::_LoadingThread::_function(Texture2D::Weak texture, std::string f
     }
     // Fill vector
     if (_is_canceled) return;
-    _pixels = RGBA32::Pixels(raw_pixels.get(), raw_pixels.get() + (_w * _h));
+    _pixels = RGBA32::Pixels(raw_pixels.get(), raw_pixels.get() + (_tex_w * _tex_h));
 
 }
 
@@ -112,7 +112,7 @@ void Texture2D::pollThreads()
         if (texture) {
             if (texture->_loading_thread.isPending()) {
                 // Give the image to the OpenGL texture
-                texture->_raw_texture.edit(&texture->_pixels[0], texture->_w, texture->_h);
+                texture->_raw_texture.edit(&texture->_pixels[0], texture->_tex_w, texture->_tex_h);
                 // Update texture scaling of all planes (they are stored in window instances)
                 Window::_textureWasEdited(std::static_pointer_cast<TextureBase>(texture));
                 // Set thread as handled.


### PR DESCRIPTION
- TextTextures now inherits from BOTH TextureBase and TR::TextArea, which improves practicality. Modified some TextureBase names to avoid conflicts.
- Button now stores its cursor relative position, and calls TextArea::placeCursor() at those given coordinates when clicked on.