### PR TITLE
Dynamic registration event handling

### DIFF
--- a/inc/GL/Objects/Camera.hpp
+++ b/inc/GL/Objects/Camera.hpp
@@ -92,7 +92,9 @@ public:
         /** Orthographic projection (2D) with a fixed pixel size.*/
         OrthoFixed,
         /** Perspective projection (3D).*/
-        Perspective
+        Perspective,
+        /** UI screen projection, with reverse Y axis (2D).*/
+        UI
     };
     /** Sets the Projection of the camera.
      *  @sa getProjectionType()

--- a/inc/GL/Objects/Model.hpp
+++ b/inc/GL/Objects/Model.hpp
@@ -4,6 +4,7 @@
 #include "Basic.hpp"
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/matrix_decompose.hpp>
+#include <SSS/Commons/eventList.hpp>
 
 /** @file
  *  Defines abstract class SSS::GL::ModelBase.
@@ -19,7 +20,8 @@ SSS_GL_BEGIN;
 /** Abstract base class for %Model matrix.
  *  @sa Plane
  */
-class SSS_GL_API ModelBase : public Subject {
+class SSS_GL_API ModelBase : public Subject, public _EventRegistry<ModelBase> {
+    friend _EventRegistry<ModelBase>;
 public:
     ModelBase();
     /** Virtual destructor, default.*/
@@ -69,6 +71,8 @@ private:
     glm::mat4 _translation;
     /** %Model matrix, computed by getModelMat4().*/
     glm::mat4 _model_mat4;
+
+    static void _register();
 };
 
 #pragma warning(pop)

--- a/inc/GL/Objects/Models/Plane.hpp
+++ b/inc/GL/Objects/Models/Plane.hpp
@@ -18,9 +18,10 @@ SSS_GL_BEGIN;
 #pragma warning(disable: 4275)
 
 /** 2D plane derived from Model.*/
-class SSS_GL_API PlaneBase : public Observer, public ModelBase {
+class SSS_GL_API PlaneBase : public Observer, public ModelBase, public _EventRegistry<PlaneBase> {
     friend class PlaneRenderer;
     friend class Window;
+    friend _EventRegistry<PlaneBase>;
     friend SSS_GL_API void pollEverything();
 
 private:
@@ -123,6 +124,8 @@ private:
         double &z, bool& is_hovered);
     // Returns true and updates z if Plane is hovered
     bool _isHovered(glm::mat4 const& VP, double x, double y, double &z);
+
+    static void _register();
 };
 
 template<class Derived>

--- a/inc/GL/Objects/Texture.hpp
+++ b/inc/GL/Objects/Texture.hpp
@@ -43,8 +43,9 @@ INTERNAL_END;
  *  internal Basic::Texture.
  *  @sa Window::createTexture()
  */
-class SSS_GL_API Texture : public Observer, public Subject, public InstancedClass<Texture> {
+class SSS_GL_API Texture : public Observer, public Subject, public InstancedClass<Texture>, public _EventRegistry<Texture> {
     friend SharedClass;
+    friend _EventRegistry<Texture>;
 
 private:
     Texture();
@@ -169,6 +170,8 @@ private:
 
     // Simple internal edit based on set type
     void _internalEdit(Type type);
+
+    static void _register();
 };
 
 #pragma warning(pop)

--- a/src/Objects/Model.cpp
+++ b/src/Objects/Model.cpp
@@ -9,7 +9,15 @@ ModelBase::ModelBase() try
     setRotation();
     setTranslation();
 }
+
+
 CATCH_AND_RETHROW_METHOD_EXC;
+
+void ModelBase::_register()
+{
+    REGISTER_EVENT("SSS_MODEL_UPDATE");
+}
+
 
 ModelBase::~ModelBase() = default;
 
@@ -58,6 +66,7 @@ void ModelBase::_computeModelMat4()
 {
     _model_mat4 = _getTranslationMat4() * _getRotationMat4() * _getScalingMat4();
     _notifyObservers();
+    EMIT_EVENT("SSS_MODEL_UPDATE");
 }
 
 void ModelBase::getAllTransformations(glm::vec3 & scaling, glm::vec3 & rot_angles, glm::vec3 & translation) const

--- a/src/Objects/Models/PlaneRenderer.cpp
+++ b/src/Objects/Models/PlaneRenderer.cpp
@@ -101,16 +101,19 @@ void PlaneRenderer::_renderPart(Shaders& shader, uint32_t& count, uint32_t& offs
 
 void PlaneRenderer::_subjectUpdate(Subject const& subject, int event_id)
 {
-    switch (event_id) {
-    case SSS::EventList::Model:
+    if (event_id == EVENT_ID("SSS_MODEL_UPDATE")) {
         _model_vbo.needs_edit = true;
-        break;
-    case SSS::EventList::Alpha:
+        return;
+    }
+
+    if (event_id == EVENT_ID("SSS_PLANE_ALPHA")) {
         _alpha_vbo.needs_edit = true;
-        break;
-    case SSS::EventList::TexOffset:
+        return;
+    }
+
+    if (event_id == EVENT_ID("SSS_PLANE_TEXTURE_OFFSET")) {
         _tex_offset_vbo.needs_edit = true;
-        break;
+        return;
     }
 }
 

--- a/src/Objects/Texture.cpp
+++ b/src/Objects/Texture.cpp
@@ -13,6 +13,13 @@ SSS_GL_BEGIN;
 
 std::string Texture::_resource_folder;
 
+
+void Texture::_register()
+{
+    REGISTER_EVENT("SSS_TEXTURE_RESIZE"); 
+    REGISTER_EVENT("SSS_TEXTURE_CONTENT"); 
+}
+
 Texture::Texture() try
     : _raw_texture(GL_TEXTURE_2D_ARRAY)
 {
@@ -228,7 +235,9 @@ void Texture::_internalEdit(Type type)
     _type = type;
     if (_type == Type::Raw) {
         if (_raw_texture.editSettings(_frames.w, _frames.h, static_cast<int>(_frames.size())))
-            _notifyObservers(SSS::EventList::Resize);
+        {
+            EMIT_EVENT("SSS_TEXTURE_RESIZE");
+        }
         for (uint32_t i = 0; i < _frames.size(); ++i) {
             _raw_texture.editPixels(_frames[i].pixels.data(), i);
         }
@@ -238,7 +247,9 @@ void Texture::_internalEdit(Type type)
         if (_area)
             _area->pixelsGetDimensions(w, h);
         if (_raw_texture.editSettings(w, h))
-            _notifyObservers(SSS::EventList::Resize);
+        {
+            EMIT_EVENT("SSS_TEXTURE_RESIZE");
+        }
         if (_area)
             _raw_texture.editPixels(_area->pixelsGet());
     }
@@ -246,12 +257,12 @@ void Texture::_internalEdit(Type type)
     if (_callback_f)
         _callback_f(*this);
 
-    _notifyObservers(SSS::EventList::Content);
-    
+    EMIT_EVENT("SSS_TEXTURE_CONTENT"); 
     // Log
     if (Log::GL::Texture::query(Log::GL::Texture::get().edit)) {
         LOG_GL_MSG("Texture -> edit");
     }
 }
+
 
 SSS_GL_END;


### PR DESCRIPTION
# Contexte
L'ancien système de communication d'event était rudimentaire et commence avec les nouveaux systèmes de Node à avoir besoin d'être étendu de manière dynamique lors de la création de nouveaux nodes

Il s'agit donc d'un refactor du système d'event avec une allocation dynamique
Une liste des events disponibles est accessible
Les noms des event peuvent être retrouvés avec leurs id

## Modifications
Refactorisation du code pour l'utilisation du nouveau système d'event dynamique